### PR TITLE
Add ledgers API

### DIFF
--- a/examples/src/private_endpoints.rs
+++ b/examples/src/private_endpoints.rs
@@ -1,5 +1,6 @@
 extern crate bitfinex;
 
+use std::time::SystemTime;
 use bitfinex::api::*;
 use bitfinex::pairs::*;
 use bitfinex::currency::*;
@@ -61,4 +62,15 @@ fn main() {
         },
         Err(e) => println!("Error: {}", e),
     }    
+
+    // LEDGER
+    let now = SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis();
+    match api.ledger.get_history(USD, now - 3600000, now, 5) {
+        Ok(entries) => {
+            for entry in &entries {
+                println!("Ledger Entry => {}{} => {}: {}", entry.amount, entry.currency, entry.balance, entry.description);
+            }
+        },
+        Err(e) => println!("Error: {}", e),
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,7 @@ use trades::*;
 use candles::*;
 use orders::*;
 use account::*;
+use ledger::*;
 
 #[derive(Clone)]
 pub struct Bitfinex {
@@ -12,18 +13,20 @@ pub struct Bitfinex {
     pub trades: Trades,
     pub candles: Candles,
     pub orders: Orders,
-    pub account: Account
+    pub account: Account,
+    pub ledger: Ledger
 }
 
 impl Bitfinex {
     pub fn new(api_key: Option<String>, secret_key: Option<String>) -> Self {
-        Bitfinex { 
+        Bitfinex {
             book: Book::new(),
             ticker: Ticker::new(),
             trades: Trades::new(),
             candles: Candles::new(),
             orders: Orders::new(api_key.clone(), secret_key.clone()),
-            account: Account::new(api_key.clone(), secret_key.clone())
+            account: Account::new(api_key.clone(), secret_key.clone()),
+            ledger: Ledger::new(api_key.clone(), secret_key.clone()),
         }
     }
 }

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -1,0 +1,50 @@
+use client::*;
+use errors::*;
+use serde_json::from_str;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Entry {
+    pub id: i64,
+    pub currency: String,
+    _field3: Option<()>,
+    pub timestamp_milli: i64,
+    _field5: Option<()>,
+    pub amount: f64,
+    pub balance: f64,
+    _field8: Option<()>,
+    pub description: String,
+}
+
+#[derive(Clone)]
+pub struct Ledger {
+    client: Client,
+}
+
+impl Ledger {
+    pub fn new(api_key: Option<String>, secret_key: Option<String>) -> Self {
+        Ledger {
+            client: Client::new(api_key, secret_key),
+        }
+    }
+
+    pub fn get_history<S>(
+        &self,
+        symbol: S,
+        _start: u128,
+        _end: u128,
+        _limit: i32,
+    ) -> Result<(Vec<Entry>)>
+    where
+        S: Into<String>,
+    {
+        let payload: String = format!("{}", "{}");
+        let request: String = format!("ledgers/{}/hist", symbol.into());
+
+        // TODO: Provide query parameters. These must not be signed.
+        let data = self.client.post_signed(request, payload)?;
+
+        let entry: Vec<Entry> = from_str(data.as_str())?;
+
+        Ok(entry)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod trades;
 mod orders;
 mod candles;
 mod account;
+mod ledger;
 
 pub mod api;
 pub mod pairs;


### PR DESCRIPTION
Query parameters shouldn't be signed. The only way to currently provide them is to add them to the URL path, which results in them being signed. For now, I've omitted them, and I'll try to add query parameter support in a separate PR.