### PR TITLE
Support Position Snapshot ('ps') channel data

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -2,6 +2,7 @@ use ticker::*;
 use candles::Candle;
 use trades::{TradingPair as TradesTradingPair, FundingCurrency as TradesFundingCurrency};
 use book::{TradingPair as BookTradingPair, FundingCurrency as BookFundingCurrency, RawBook};
+use positions::Position;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -32,6 +33,7 @@ pub enum DataEvent {
     RawBookUpdateEvent (i32, Vec<RawBook>),
     CandlesSnapshotEvent (i32, Vec<Candle>),
     CandlesUpdateEvent (i32, Candle),
+    PositionSnapshotEvent (i32, String, Vec<Position>),
     HeartbeatEvent (i32, String)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod candles;
 mod account;
 mod ledger;
 mod auth;
+mod positions;
 
 pub mod api;
 pub mod pairs;

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Deserialize)]
+pub struct Position {
+    pub symbol: String,
+    pub status: String,
+    pub amount: f64,
+    pub base_price: f64,
+    pub margin_funding: f64,
+    pub margin_funding_type: u8,
+    pub pl: f64,
+    pub pl_perc: f64,
+    pub price_liq: f64,
+    pub leverage: f64,
+}


### PR DESCRIPTION
I'm not sure if this should be added as part of `DataEvent`. The structure is somewhat different for  authenticated channel events. Looking at the [NodeJS implementation](https://github.com/bitfinexcom/bitfinex-api-node/blob/abd02f4aea9a276c37fc604c36470a812c8f81b4/lib/transports/ws2.js#L574), public channel events are handled in a special way, and the default is to handle authenticated channel data. This implementation's logic is a bit different.

https://docs.bitfinex.com/v2/reference#ws-auth-position