### PR TITLE
add missing parameter

### DIFF
--- a/examples/src/public_endpoints.rs
+++ b/examples/src/public_endpoints.rs
@@ -70,7 +70,7 @@ fn main() {
         Err(e) => println!("Error: {}", e),
     }    
 
-    let history = api.candles.history(ETHUSD, "12h");
+    let history = api.candles.history(ETHUSD, "12h", &CandleHistoryParams::new());
     match history {
         Ok(candles) => {
             for candle in &candles {


### PR DESCRIPTION
This example won't compile without `CandleHistoryParams`.