### PR TITLE
Corrected trade update structure

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Usage
 
-## Private Endpoins
+## Private Endpoints
 
 cargo run --release --bin "private_endpoints"
 

--- a/examples/src/public_channels.rs
+++ b/examples/src/public_channels.rs
@@ -26,9 +26,11 @@ impl EventHandler for WebSocketHandler {
 
     fn on_data_event(&mut self, event: DataEvent) {
         if let DataEvent::TickerTradingEvent(channel, trading) = event {
-            println!("Ticker Trading ({})- Bid {:?}, Ask: {}", channel, trading.bid, trading.ask);
+            println!("Ticker Trading ({}) - Bid {:?}, Ask: {}", channel, trading.bid, trading.ask);
         } else if let DataEvent::RawBookEvent(channel, raw_book) = event {
             println!("Raw book ({}) - Price {:?}, Amount: {}", channel, raw_book.price, raw_book.amount);
+        } else if let DataEvent::TradesTradingUpdateEvent(channel, pair, trading) = event {
+            println!("Trade update ({}) - Id: {}, Time: {}, Price: {}, Amount: {}", channel, trading.id, trading.mts, trading.price, trading.amount);
         }
         // ... Add for all events you have subscribed (Trades, Books, ...)
     }

--- a/src/trades.rs
+++ b/src/trades.rs
@@ -6,7 +6,7 @@ use serde_json::from_str;
 pub struct Trade {
     pub id: i64,
     pub pair: String,
-    pub execution_timestap: i64,
+    pub execution_timestamp: i64,
     pub order_id: i32,
     pub execution_amount: f64,
     pub execution_price: f64,
@@ -19,10 +19,10 @@ pub struct Trade {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TradingPair {
+    pub id: i64,
     pub mts: i64,
     pub amount: f64,
-    pub price: f64,
-    pub rate: f64
+    pub price: f64
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Identified that trades on websocket channel were not correctly formatted. This PR corrects that structure as documented on Bitfinex: https://docs.bitfinex.com/reference#ws-public-trades